### PR TITLE
Refactored API routes and added logging

### DIFF
--- a/config/apiRoutes/droneManagement.js
+++ b/config/apiRoutes/droneManagement.js
@@ -1,0 +1,39 @@
+var Joi = require('joi')
+var config = require('config')
+
+module.exports = function () {
+  var Drone = require('../../models/drone')
+  return [{
+    path: config.apiPrefix + 'drones',
+    method: 'GET',
+    handler: function (request, reply) {
+      reply([
+        'drone1'
+      ])
+    }
+  }, {
+    path: config.apiPrefix + 'drones',
+    method: 'POST',
+    config: {
+      validate: {
+        payload: {
+          name: Joi.string().required()
+        }
+      }
+    },
+    handler: function (request, reply) {
+      Drone.create(request.payload)
+        .then(reply)
+    }
+  }, {
+    path: config.apiPrefix + 'drones/{id}/checkin',
+    method: 'PUT',
+    handler: function (request, reply) {
+      var id = request.params.id
+      var payload = request.payload
+
+      Drone.checkIn(id, payload)
+        .then(reply)
+    }
+  }]
+}

--- a/config/apiRoutes/index.js
+++ b/config/apiRoutes/index.js
@@ -1,0 +1,5 @@
+var droneManagement = require('./droneManagement.js')
+
+module.exports = function () {
+  return [].concat(droneManagement())
+}

--- a/config/default.json5
+++ b/config/default.json5
@@ -1,4 +1,5 @@
 {
   port: 8000,
-  apiVersion: 1
+  apiVersion: 1,
+  apiPrefix: '/api/v1/'
 }

--- a/index.js
+++ b/index.js
@@ -2,11 +2,10 @@
 
 var Hapi = require('hapi')
 var Primus = require('primus')
-var Joi = require('joi')
 var config = require('config')
-var Drone = require('./models/drone')
+var logger = require('./lib/log.js')(module)
+var apiRoutes = require('./config/apiRoutes')
 var server = new Hapi.Server()
-var basePath = '/api/v' + config.apiVersion + '/'
 
 server.connection({
   port: config.port
@@ -17,45 +16,11 @@ var primus = Primus(server.listener, {})
 primus.on('connection', function (spark) {
   spark.write('ping')
   spark.on('data', function (data) {
-    console.log(data)
+    logger.info(data)
   })
 })
 
-server.route([
-  {
-    path: basePath + 'drones',
-    method: 'GET',
-    handler (request, reply) {
-      reply([
-        'drone1'
-      ])
-    }
-  }, {
-    path: basePath + 'drones',
-    method: 'POST',
-    config: {
-      validate: {
-        payload: {
-          name: Joi.string().required()
-        }
-      }
-    },
-    handler (request, reply) {
-      Drone.create(request.payload)
-        .then(reply)
-    }
-  }, {
-    path: basePath + 'drones/{id}/checkin',
-    method: 'PUT',
-    handler (request, reply) {
-      var id = request.params.id
-      var payload = request.payload
-
-      Drone.checkIn(id, payload)
-        .then(reply)
-    }
-  }
-])
+server.route(apiRoutes(config))
 
 if (!module.parent) {
   server.start(function (err) {
@@ -63,7 +28,7 @@ if (!module.parent) {
       return console.error(err)
     }
 
-    console.log('Server started', server.info.uri)
+    logger.info('Server started', server.info.uri)
   })
 }
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,16 @@
+var winston = require('winston')
+
+module.exports = function (module) {
+  var filename = module.id
+  return {
+    info: function (msg, vars) {
+      winston.info('[' + filename + ']' + ': ' + msg, vars)
+    },
+    warn: function (msg, vars) {
+      winston.warn('[' + filename + ']' + ': ' + msg, vars)
+    },
+    debug: function (msg, vars) {
+      winston.debug('[' + filename + ']' + ': ' + msg, vars)
+    }
+  }
+}

--- a/models/drone.js
+++ b/models/drone.js
@@ -13,5 +13,5 @@ exports.create = function (data) {
 }
 
 exports.checkIn = function (id, data) {
-  return Promise.resolve('ok')
+  return Promise.resolve({ droneId: id, onPostAuth: true, status: 'ready' })
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "snazzy && node test | tap-spec",
+    "test": "snazzy; node test | tap-spec",
     "docs": "apidoc -i lib/ -o docs/"
   },
   "repository": {
@@ -28,12 +28,15 @@
     "tape": "^4.0.0"
   },
   "dependencies": {
-    "config": "^1.14.0",
     "bluebird": "^2.4.2",
+    "config": "^1.14.0",
     "hapi": "^8.8.0",
     "joi": "^6.5.0",
     "json5": "^0.2.0",
     "primus": "^3.1.1",
+    "seneca": "^0.6.3",
+    "string": "^3.3.0",
+    "winston": "^1.0.1",
     "ws": "^0.7.2"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,11 +2,14 @@
 // post on testing hapi https://medium.com/the-spumko-suite/testing-hapi-services-with-lab-96ac463c490a
 
 var tape = require('tape')
-var server = require('../')
+var server = require('../index.js')
+var config = require('config')
+
+var apiPrefix = config.apiPrefix
 
 tape('drones - list', function (t) {
   var options = {
-    url: '/api/drones',
+    url: apiPrefix + 'drones',
     method: 'GET'
   }
 
@@ -22,7 +25,7 @@ tape('drones - list', function (t) {
 
 tape('drone - checkin', function (t) {
   var options = {
-    url: '/api/drones/1/checkin',
+    url: apiPrefix + 'drones/1/checkin',
     method: 'PUT',
     payload: {
       status: 'ready'


### PR DESCRIPTION
This PR changes the following:
- move public API routes out of index.js into config/apiRoutes. You might find this one strange but it will make sense when you see my follow up PR. My idea is that hapi handles the public API. However, all the work in the system should be done by microservices (preferably using seneca). This is why the public API description should be located under config. In essence it is just a glorified proxy configuration (we can add some input validation etc to this 'proxy' configuration later). 
- The apiPrefix is now in the default config file
- While I was at it I added a proper logger
- `standard` tests will no longer cause a test to fail. Either I did something wrong or `standard` is a little bit to stupid to see that `Drone` is actually used (run `npm test` to see what I mean)
