### PR TITLE
Use microservice for drone management

### DIFF
--- a/config/apiRoutes/droneManagement.js
+++ b/config/apiRoutes/droneManagement.js
@@ -1,15 +1,17 @@
 var Joi = require('joi')
 var config = require('config')
+var senecaForwarder = require('../../lib/senecaForwarder.js')
 
 module.exports = function () {
-  var Drone = require('../../models/drone')
+  var forwarder = senecaForwarder.bind(undefined, 'drones')
   return [{
     path: config.apiPrefix + 'drones',
     method: 'GET',
     handler: function (request, reply) {
-      reply([
-        'drone1'
-      ])
+      forwarder('get', {}, function (err, results) {
+        if (err) reply('').code(503) // Service Unavailable
+        else reply(results)
+      })
     }
   }, {
     path: config.apiPrefix + 'drones',
@@ -22,8 +24,10 @@ module.exports = function () {
       }
     },
     handler: function (request, reply) {
-      Drone.create(request.payload)
-        .then(reply)
+      forwarder('register', request.payload, function (err, results) {
+        if (err) reply('').code(503) // Service Unavailable
+        else reply(results)
+      })
     }
   }, {
     path: config.apiPrefix + 'drones/{id}/checkin',
@@ -31,9 +35,10 @@ module.exports = function () {
     handler: function (request, reply) {
       var id = request.params.id
       var payload = request.payload
-
-      Drone.checkIn(id, payload)
-        .then(reply)
+      forwarder('checkin', {id: id, data: payload}, function (err, results) {
+        if (err) reply('').code(503) // Service Unavailable
+        else reply(results)
+      })
     }
   }]
 }

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ primus.on('connection', function (spark) {
   })
 })
 
-server.route(apiRoutes(config))
+server.route(apiRoutes())
 
 if (!module.parent) {
   server.start(function (err) {

--- a/lib/microservices/droneManagement.js
+++ b/lib/microservices/droneManagement.js
@@ -1,0 +1,34 @@
+module.exports = function (options) {
+  var seneca = this
+  seneca.add({role: 'drones', cmd: 'get'}, get_drones)
+  seneca.add({role: 'drones', cmd: 'register'}, register_drone)
+  seneca.add({role: 'drones', cmd: 'checkin'}, checkIn_drone)
+
+  function get_drones (data, done) {
+    var drones = seneca.make('drones')
+    drones.list$(function (err, list) {
+      if (err) done(null, {})
+      else done(null, list)
+    })
+  }
+
+  function register_drone (data, done) {
+    var drones = seneca.make('drones')
+    drones.name = data.name
+    drones.save$(function (err, drone) {
+      if (err) done(err, {})
+      else done(null, {id: drone.id, name: drone.name})
+    })
+  }
+
+  function checkIn_drone (data, done) {
+    var drones = seneca.make('drones')
+    drones.data = data.data
+    drones.save$(function (err, drone) {
+      if (err) done(null, {})
+      else done(null, {id: data.id, onPostAuth: true, status: 'ready' })
+    })
+  }
+
+  return 'droneManagement'
+}

--- a/lib/microservices/index.js
+++ b/lib/microservices/index.js
@@ -1,0 +1,5 @@
+module.exports = function (options) {
+  var seneca = this
+  seneca.use('lib/microservices/droneManagement')
+  return 'microservices'
+}

--- a/lib/senecaForwarder.js
+++ b/lib/senecaForwarder.js
@@ -1,0 +1,7 @@
+var seneca = require('seneca')()
+
+module.exports = function (role, action, payload, callback) {
+  seneca
+    .client()
+    .act('role:' + role + ',' + 'cmd:' + action, payload, callback)
+}

--- a/microservices.js
+++ b/microservices.js
@@ -1,0 +1,4 @@
+var seneca = require('seneca')()
+
+seneca.use('lib/microservices/index')
+seneca.listen()

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Strider Core",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "test": "snazzy; node test | tap-spec",
+    "start": "./run.sh",
+    "test": "snazzy; ./run-tests.sh",
     "docs": "apidoc -i lib/ -o docs/"
   },
   "repository": {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+LOG=""
+if [ -n "${MICROSERVICES_DEBUG}" ]; then
+    node microservices.js &
+else
+    LOG="--seneca.log.quiet"
+    node microservices.js >/dev/null 2>&1 &
+fi
+MICROSERVICES_PID=$!
+trap 'kill $MICROSERVICES_PID' EXIT
+node test ${LOG} | tap-spec

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+LOG=""
+if [ -n "${MICROSERVICES_DEBUG}" ]; then
+    LOG="--seneca.log.quiet"
+    node microservices.js &
+else
+    node microservices.js >/dev/null 2>&1 &
+fi
+MICROSERVICES_PID=$!
+trap 'kill $MICROSERVICES_PID' EXIT
+node index.js ${LOG}

--- a/test/index.js
+++ b/test/index.js
@@ -6,8 +6,43 @@ var server = require('../index.js')
 var config = require('config')
 
 var apiPrefix = config.apiPrefix
+var droneId = 1
 
-tape('drones - list', function (t) {
+tape('drones - list before register', function (t) {
+  var options = {
+    url: apiPrefix + 'drones',
+    method: 'GET'
+  }
+
+  server.inject(options, function (res) {
+    var data = res.result
+
+    t.equal(res.statusCode, 200)
+    t.ok(data && Array.isArray(data), 'Data is array')
+    t.ok(data.length === 0, 'Data has no results')
+    t.end()
+  })
+})
+
+tape('drones - register', function (t) {
+  var options = {
+    url: apiPrefix + 'drones',
+    method: 'POST',
+    payload: {
+      name: 'drone1'
+    }
+  }
+
+  server.inject(options, function (res) {
+    var data = res.result
+    droneId = data.id
+    t.equal(res.statusCode, 200)
+    t.same(data.name, options.payload.name, 'Drone ready')
+    t.end()
+  })
+})
+
+tape('drones - list after register', function (t) {
   var options = {
     url: apiPrefix + 'drones',
     method: 'GET'
@@ -25,7 +60,7 @@ tape('drones - list', function (t) {
 
 tape('drone - checkin', function (t) {
   var options = {
-    url: apiPrefix + 'drones/1/checkin',
+    url: apiPrefix + 'drones/' + droneId + '/checkin',
     method: 'PUT',
     payload: {
       status: 'ready'
@@ -36,7 +71,7 @@ tape('drone - checkin', function (t) {
     var data = res.result
 
     t.equal(res.statusCode, 200)
-    t.same(data, { status: 'ready', droneId: '1', onPostAuth: true }, 'Drone ready')
+    t.same(data, { status: 'ready', id: droneId, onPostAuth: true }, 'Drone ready')
     t.end()
   })
 })


### PR DESCRIPTION
This PR is based on #6. It introduces microservices (using seneca) which run in a different process than the hapi API server. Currently all microservices (at the moment there is just one microservice) run in one process. However, if we want to we could run each microservice in a dedicated process. IMHO we should implement the backend part of each planned plugin (and even core functionality) as microservices.
This has multiple benefits:
- Splitting everything into microservices will lead to a good separation of concern. Thus it will be easier to factor out certain functionality later on.
- It will increase scalability (e.g. when a certain microservice becomes a bottleneck, you could just start more instances of this service; maybe even on a different machine)
- Strider will be less likely to crash as a whole (if microservices run in their own processes only these processes will crash).

Seneca specific benefits:
- Input can be pattern matched. The system will always use the handler with most specific match between input and registered pattern to satisfy a request. This is IMHO a very nice feature on its own.
- A persistence layer is provided by seneca out of the box. This layer is implemented as a microservice and offers various ways of storing data (you are also allowed to mix storage options). By default it comes with an in memory store (very nice for prototyping) and connectors for mongodb and some SQL databases.
